### PR TITLE
fix: fix PR template position in folder structure.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+*follow the instructions below*
+
+#### 📋 Pull Request Naming Convention
+
+- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+- Put youtrack task id in end of PR name, started from `#` symbol, for example `#RSS_ECOMM-1`.
+
+* [ ] I followed naming convention rules.
+
+--------------------------------
+
+#### 🤔 This is a ...
+
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Performance optimization
+- [ ] Refactoring
+- [ ] Test Case
+- [ ] Documentation update
+- [ ] Other
+
+#### ⚒ Related youtrack task link
+
+_Describe the source of requirement, like related issue link._
+
+#### 💡 Background and solution
+
+_Describe shortly the task or problem and solution here_
+
+#### Self Check before Merge
+
+⚠️ Please check all items below before review. ⚠️
+
+- [ ] Correct head and base ref`s for Pull Request.


### PR DESCRIPTION
*follow the instructions below*

#### 📋 Pull Request Naming Convention

- Title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- Put youtrack task id in end of PR name, started from `#` symbol, for example `#RSS_ECOMM-1`.

* [x] I followed naming convention rules.

--------------------------------

#### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Test Case
- [ ] Documentation update
- [ ] Other

#### ⚒ Related youtrack task link

Fix after work according [RSS_ECOMM-5](https://russianspacehummer.youtrack.cloud/agiles/121-11/current?issue=RSS_ECOMM-5).

#### 💡 Background and solution

Fix PR template position in folder structure.

#### Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Correct head and base ref`s for Pull Request.
